### PR TITLE
Add initial support for policy file and "restricted sharing"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "typescript.tsc.autoDetect": "off",
     "extensions.ignoreRecommendations": true,
     "files.autoSave": "off",
-    "debug.allowBreakpointsEverywhere": true
+    "debug.allowBreakpointsEverywhere": true,
+    "editor.formatOnSave": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+## v0.0.3 (06/30/2020)
+
+- Added support for restricting sharing to only allowed domains
+- Added support for defining the list of allowed domains via a config file
+
 ## v0.0.2 (05/12/2020)
 
 - Added support for enforcing certain settings (see readme for details)
-  
+
 ## v0.0.1 (05/01/2020)
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Live Share Gatekeeper 💂
 
-Live Share Gatekeeper enforces a stricter "mode" of collaboration, for organizations that want the benefits of real-time interaction, while respecting their security/compliance policies. In particular, this extensions allows you to prevent Live Share guests from joining a collaboration session that aren't members of the same domain/AAD tenant. This prevents anonymous users, users outside your organization, or users outside of a specified set of domains (e.g. `microsoft.com`) from being able to collaborating with you, regardless if they got access to the session URL. Additionally, it automatically enforces a set of policies, so that user's can't accidentally share unintended resources (e.g. read/write terminals).
+Live Share Gatekeeper enforces a stricter "mode" of collaboration, for organizations that want the benefits of real-time interaction, while respecting their security/compliance policies. In particular, this extensions allow you to prevent Live Share guests from joining a collaboration session that aren't members of the same domain/AAD tenant. This prevents anonymous users, users outside your organization, or users outside of a specified set of domains (e.g. `microsoft.com`) from being able to collaborating with you, regardless if they got access to the session URL. Additionally, it automatically enforces a set of policies, so that user's can't accidentally share unintended resources (e.g. read/write terminals).
 
 ## Getting Started
 
@@ -8,6 +8,7 @@ Live Share Gatekeeper enforces a stricter "mode" of collaboration, for organizat
 1. Reload Visual Studio Code
 1. Start a Live Share session
 1. If a guest tries to join the session, that's either anonymous, or is authenticated with a different domain than you (e.g. `@microsoft.com`), they will be immediately blocked
+1. _(Optional)_ [Explicitly configure](#configuring-allowed-domains) the set of allowed domains to have even greater control
 
 If needed, you can then easily [automate](#automating-installation) the installation of this extension on every developer's machine in your organization, in order to provide a centrally-managed experience.
 
@@ -23,6 +24,22 @@ code --install-extension vsls-contrib.gatekeeper
 
 This will ensure that developer's always have the latest version of Gatekeeper installed. Additionally, since Gatekeeper takes a dependency on the Live Share extension as well, you can simply install Gatekeeper, which will take care of installing and configuring everything that developer's need to start securely collaborating!
 
+## Configuring Allowed Domains
+
+By default, Gatekeeper restricts collaboration within the same domain that the host is currently signed in with (e.g. `microsoft.com`). However, if your organization wants to prevent developer's from using non-work accounts, and/or authorize the use of a broader set of domains (e.g. to support subsidiaries/"guest" tenants), then you can explicitly configure the set of allowed domains via a config file. This file should be place at `$HOME/liveshare-policy.json` and contains the following schema:
+
+```json
+{
+  "allowedDomains": ["foo.com", "bar.net"]
+}
+```
+
+> Alternatively, the set of allowed domains can be configured via the `Live Share > Allowed Domains` VS Code setting. When both sources exist, the contents of the config file will take precedence, which allows for a centrally managed solution.
+
+When a set of allowed domains is configured, then the host is required to authenticate with Live Share using one of those domains. If they aren't, then they will receive the following error when they attempt to share their workspace:
+
+<img width="500px" src="https://user-images.githubusercontent.com/116461/86175551-66493f00-bad8-11ea-9f22-9fe90c478da9.png" />
+
 ## Enforced Settings
 
 In addition to rejecting anonymous/external guests, this extension also enforces the following settings, by automatically setting them to `false`:
@@ -32,9 +49,3 @@ In addition to rejecting anonymous/external guests, this extension also enforces
 - `Liveshare: Auto Share Servers`
 
 > These settings are automatically set to `false` every time the user runs VS Code. However, the user can still set them back to `true` within a VS Code session.
-
-## Contributed Settings
-
-By default, this extension blocks all guests who are authenticated with a different domain than the host. However, if you'd like to expand the scope of allowed domains, you can specify the following setting:
-
-- `Live Share: Allowed Domains` - Specifies the set of domains that guests are allowed be authenticated with. Defaults to `[]` which only allows guests from the same domain as the host.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,9 @@
 {
-	"name": "doorman",
-	"version": "0.0.1",
+	"name": "gatekeeper",
+	"version": "0.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/mocha": {
-			"version": "2.2.48",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-			"integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
-			"dev": true
-		},
 		"@types/node": {
 			"version": "8.10.59",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,12 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import * as vscode from "vscode";
 import * as vsls from "vsls";
 
 const EXTENSION_NAME = "liveshare";
+const POLICY_FILE = "liveshare-policy.json";
+
 export async function activate(context: vscode.ExtensionContext) {
   // Ensure the neccessary settings are
   // re-enforced for the end-user.
@@ -11,6 +16,31 @@ export async function activate(context: vscode.ExtensionContext) {
   // Live Share, so it will always be available.
   const api = (await vsls.getApi())!;
 
+  // Wait to see if the host attempts to share,
+  // and is using a disallowed identity.
+  api.onDidChangeSession(async (e) => {
+    if (e.session) {
+      const allowedDomains = getAllowedDomains();
+
+      if (
+        allowedDomains.length > 0 &&
+        !allowedDomains.includes(getDomain(api.session)!)
+      ) {
+        const domains = allowedDomains.sort().join(", ");
+        api.end();
+
+        if (
+          await vscode.window.showErrorMessage(
+            `You need to sign into Live Share using one of the following allowed domains: ${domains}. Please sign-in and share again.`,
+            "Sign in"
+          )
+        ) {
+          await reSignIn();
+        }
+      }
+    }
+  });
+
   // Wait for any guests to attempt to join
   // a collaboration session, in order to
   // determine if they're allowed in or not.
@@ -18,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
     e.added.forEach((peer) => {
       // If the current user doesn't have an e-mail address, then
       // there's no point in us trying to match it against guests.
-      const selfDomain = api.session.user?.emailAddress?.split("@")[1];
+      const selfDomain = getDomain(api.session);
       if (!selfDomain) {
         return;
       }
@@ -26,7 +56,7 @@ export async function activate(context: vscode.ExtensionContext) {
       // If the incoming user doesn't have an e-mail address,
       // then immediately remove them, since anonymous/unknown
       // guests aren't allowed, regardless of the host's settings.
-      const emailDomain = peer.user?.emailAddress?.split("@")[1];
+      const emailDomain = getDomain(peer);
       if (!emailDomain) {
         return removeUser(peer.peerNumber);
       }
@@ -37,9 +67,7 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
       }
 
-      const allowedDomains: string[] = vscode.workspace
-        .getConfiguration(EXTENSION_NAME)
-        .get("allowedDomains", []);
+      const allowedDomains = getAllowedDomains();
 
       // If the incoming user is from a different domain,
       // which hasn't been whitelisted, then remove them.
@@ -50,16 +78,10 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 }
 
-function removeUser(peerNumber: number) {
-  vscode.commands.executeCommand(`${EXTENSION_NAME}.removeParticipant`, {
-    sessionId: peerNumber,
-  });
-}
-
 const SETTINGS = [
   "allowGuestDebugControl",
   "allowGuestTaskControl",
-  "autoShareServers"
+  "autoShareServers",
 ];
 
 async function enforceSettings() {
@@ -69,4 +91,42 @@ async function enforceSettings() {
       config.update(setting, false, vscode.ConfigurationTarget.Global)
     )
   );
+}
+
+function getAllowedDomains(): string[] {
+  // Attempt to read the list of allowed domains
+  // from the central policy file (if it exists).
+  const filePath = path.join(os.homedir(), POLICY_FILE);
+  if (fs.existsSync(filePath)) {
+    const contents = fs.readFileSync(filePath, "utf8");
+
+    try {
+      const policy = JSON.parse(contents);
+      if (policy.allowedDomains) {
+        return policy.allowedDomains;
+      }
+    } catch {
+      // The policy file wasn't valid JSON
+      // and so silently move on.
+    }
+  }
+
+  return vscode.workspace
+    .getConfiguration(EXTENSION_NAME)
+    .get("allowedDomains", []);
+}
+
+function getDomain(peerOrSession: vsls.Peer | vsls.Session) {
+  return peerOrSession.user?.emailAddress?.split("@")[1];
+}
+
+function removeUser(peerNumber: number) {
+  vscode.commands.executeCommand(`${EXTENSION_NAME}.removeParticipant`, {
+    sessionId: peerNumber,
+  });
+}
+
+async function reSignIn() {
+  await vscode.commands.executeCommand(`${EXTENSION_NAME}.signout`);
+  await vscode.commands.executeCommand(`${EXTENSION_NAME}.signInAndReload`);
 }


### PR DESCRIPTION
This PR fixes #4 and #5, by introducing two product enhancements:

1. Disallows sharing your workspace when a set of allowed domains are configured, and you're signed in with an identity that isn't in that list

1. Allows you to configure the set of allowed domains in a central policy file (`$HOME/liveshare-policy.json`) in addition to the existing VS Code setting
