### PR TITLE
Adjust gatekeeper to use new VSLS policy API

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,18 @@
     "configuration": {
       "title": "Live Share Gatekeeper Configuration",
       "properties": {
-        "liveshare.allowedDomains": {
+        "gatekeeper.allowedDomains": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
           "description": "Specifies the set of domains that guests are allowed be authenticated with."
+        },
+        "gatekeeper.allowReadWriteTerminals": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether or not a read-write terminal can be instantiated within Live Share session."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,14 +19,16 @@ class TestPolicyProvider implements vsls.PolicyProvider {
 
   policies: vsls.Policy[] = [
     new GenericPolicy(vsls.SettingKey.AllowGuestDebugControl, false),
-    new GenericPolicy(vsls.SettingKey.AllowGuestTaskControl, false),
-    new GenericPolicy(vsls.SettingKey.AutoShareServers, false)
+    new GenericPolicy(vsls.SettingKey.AllowGuestTaskControl, false, true),
+    new GenericPolicy(vsls.SettingKey.AutoShareServers, false, true),
+    new GenericPolicy(vsls.SettingKey.AnonymousGuestApproval, "reject"),
+    new GenericPolicy(vsls.SettingKey.ConnectionMode, "direct")
   ];
 }
 
 class GenericPolicy implements vsls.Policy {
 
-  constructor(settingKey: vsls.SettingKey, value: any, isUserLevel: boolean = true) {
+  constructor(settingKey: vsls.SettingKey, value: any, isUserLevel: boolean = false) {
     this.isUserLevel = isUserLevel;
     this.value = value;
     this.settingKey = settingKey;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,16 +6,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   let policyProvider = new TestPolicyProvider();
   api.registerPolicyProvider("Strict Policy Provider", policyProvider);
-
-  // await vscode.window.showErrorMessage("Hi! This message comes from gatekeeper extension. Close the notification to turn my policies off.");
-  // handler?.dispose();
 }
 
 class TestPolicyProvider implements vsls.PolicyProvider {
 
   policies: vsls.Policy[] = [
     new GenericPolicy(vsls.PolicyTitle.AnonymousGuestApproval, "reject"),
-    new GenericPolicy(vsls.PolicyTitle.ConnectionMode, "direct"),
+    new GenericPolicy(vsls.PolicyTitle.ConnectionMode, "relay"),
     new GenericPolicy(vsls.PolicyTitle.AutoShareServers, false),
     new GenericPolicy(vsls.PolicyTitle.ReadOnlyTerminals, true),
     new GenericPolicy(vsls.PolicyTitle.AllowedDomains, [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,27 +2,24 @@ import * as vscode from "vscode";
 import * as vsls from "vsls";
 
 export async function activate(context: vscode.ExtensionContext) {
-
-  // This extension takes a hard depedency on
-  // Live Share, so it will always be available.
   const api = (await vsls.getApi())!;
 
-  // Wait for any guests to attempt to join
-  // a collaboration session, in order to
-  // determine if they're allowed in or not.
-
   let policyProvider = new TestPolicyProvider();
-  api.registerPolicyProvider("Test Policy Provider", policyProvider);
+  let handler = api.registerPolicyProvider("Strict Policy Provider", policyProvider);
+
+  await vscode.window.showErrorMessage("Hi! This message comes from gatekeeper extension. Close the notification to turn my policies off.");
+  handler?.dispose();
 }
 
 class TestPolicyProvider implements vsls.PolicyProvider {
 
   policies: vsls.Policy[] = [
+    new GenericPolicy(vsls.SettingKey.AnonymousGuestApproval, "accept"),
     new GenericPolicy(vsls.SettingKey.AllowGuestDebugControl, false),
-    new GenericPolicy(vsls.SettingKey.AllowGuestTaskControl, false, true),
-    new GenericPolicy(vsls.SettingKey.AutoShareServers, false, true),
-    new GenericPolicy(vsls.SettingKey.AnonymousGuestApproval, "reject"),
-    new GenericPolicy(vsls.SettingKey.ConnectionMode, "direct")
+    new GenericPolicy(vsls.SettingKey.AllowedDomains, [
+      "microsoft.com",
+      "github.com"
+    ]),
   ];
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,35 +5,36 @@ export async function activate(context: vscode.ExtensionContext) {
   const api = (await vsls.getApi())!;
 
   let policyProvider = new TestPolicyProvider();
-  let handler = api.registerPolicyProvider("Strict Policy Provider", policyProvider);
+  api.registerPolicyProvider("Strict Policy Provider", policyProvider);
 
-  await vscode.window.showErrorMessage("Hi! This message comes from gatekeeper extension. Close the notification to turn my policies off.");
-  handler?.dispose();
+  // await vscode.window.showErrorMessage("Hi! This message comes from gatekeeper extension. Close the notification to turn my policies off.");
+  // handler?.dispose();
 }
 
 class TestPolicyProvider implements vsls.PolicyProvider {
 
   policies: vsls.Policy[] = [
-    new GenericPolicy(vsls.SettingKey.AnonymousGuestApproval, "accept"),
-    new GenericPolicy(vsls.SettingKey.AllowGuestDebugControl, false),
-    new GenericPolicy(vsls.SettingKey.AllowedDomains, [
+    new GenericPolicy(vsls.PolicyTitle.AnonymousGuestApproval, "accept"),
+    new GenericPolicy(vsls.PolicyTitle.AllowGuestDebugControl, false),
+    new GenericPolicy(vsls.PolicyTitle.AllowedDomains, [
       "microsoft.com",
       "github.com"
     ]),
+    new GenericPolicy(vsls.PolicyTitle.ReadOnlyTerminal, true)
   ];
 }
 
 class GenericPolicy implements vsls.Policy {
 
-  constructor(settingKey: vsls.SettingKey, value: any, isUserLevel: boolean = false) {
+  constructor(policyTitle: vsls.PolicyTitle, value: any, isUserLevel: boolean = false) {
     this.isUserLevel = isUserLevel;
     this.value = value;
-    this.settingKey = settingKey;
+    this.policyTitle = policyTitle;
   }
 
   isUserLevel: boolean;
   
   value: any;
   
-  settingKey: vsls.SettingKey;
+  policyTitle: vsls.PolicyTitle;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,32 +12,32 @@ class TestPolicyProvider implements vsls.PolicyProvider {
 
   providePolicies(): vsls.Policy[] {
     return [
-      new GenericPolicy(vsls.PolicyTitle.AnonymousGuestApproval, "reject"),
-      new GenericPolicy(vsls.PolicyTitle.ConnectionMode, "relay"),
-      new GenericPolicy(vsls.PolicyTitle.AutoShareServers, false),
-      new GenericPolicy(vsls.PolicyTitle.AllowReadWriteTerminals, false),
-      new GenericPolicy(vsls.PolicyTitle.AllowedDomains, [
+      new GenericPolicy(vsls.PolicySetting.AnonymousGuestApproval, "reject"),
+      new GenericPolicy(vsls.PolicySetting.ConnectionMode, "relay"),
+      new GenericPolicy(vsls.PolicySetting.AutoShareServers, false),
+      new GenericPolicy(vsls.PolicySetting.AllowReadWriteTerminals, false),
+      new GenericPolicy(vsls.PolicySetting.AllowedDomains, [
         "microsoft.com",
         "github.com"
       ]),
   
-      new GenericPolicy(vsls.PolicyTitle.AllowGuestDebugControl, false, true),
-      new GenericPolicy(vsls.PolicyTitle.AllowGuestTaskControl, false, true)
+      new GenericPolicy(vsls.PolicySetting.AllowGuestDebugControl, false, true),
+      new GenericPolicy(vsls.PolicySetting.AllowGuestTaskControl, false, true)
     ];
   }
 }
 
 class GenericPolicy implements vsls.Policy {
 
-  constructor(policyTitle: vsls.PolicyTitle, value: any, isUserLevel: boolean = false) {
-    this.isUserLevel = isUserLevel;
+  constructor(policyStting: vsls.PolicySetting, value: any, isEnforced: boolean = false) {
+    this.isEnforced = isEnforced;
     this.value = value;
-    this.policyTitle = policyTitle;
+    this.policySetting = policyStting;
   }
 
-  isUserLevel: boolean;
+  isEnforced: boolean;
   
   value: any;
   
-  policyTitle: vsls.PolicyTitle;
+  policySetting: vsls.PolicySetting;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,8 +13,8 @@ export async function activate(context: vscode.ExtensionContext) {
   // Live Share, so it will always be available.
   const api = (await vsls.getApi())!;
 
-  let policyProvider = new TestPolicyProvider();
-  api.registerPolicyProvider("Sample Provider", policyProvider);
+  let policyProvider = new GatekeeperPolicyProvider();
+  api.registerPolicyProvider("Gatekeeper Provider", policyProvider);
 
   const activityLog = new ActivityLog();
   await activityLog.openAsync();
@@ -23,7 +23,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 }
 
-class TestPolicyProvider implements vsls.PolicyProvider {
+class GatekeeperPolicyProvider implements vsls.PolicyProvider {
   providePolicies(): vsls.Policy[] {
     return [
       new GenericPolicy(vsls.PolicySetting.AnonymousGuestApproval, "reject"),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,24 +5,26 @@ export async function activate(context: vscode.ExtensionContext) {
   const api = (await vsls.getApi())!;
 
   let policyProvider = new TestPolicyProvider();
-  api.registerPolicyProvider("Strict Policy Provider", policyProvider);
+  api.registerPolicyProvider("Sample Provider", policyProvider);
 }
 
 class TestPolicyProvider implements vsls.PolicyProvider {
 
-  policies: vsls.Policy[] = [
-    new GenericPolicy(vsls.PolicyTitle.AnonymousGuestApproval, "reject"),
-    new GenericPolicy(vsls.PolicyTitle.ConnectionMode, "relay"),
-    new GenericPolicy(vsls.PolicyTitle.AutoShareServers, false),
-    new GenericPolicy(vsls.PolicyTitle.ReadOnlyTerminals, true),
-    new GenericPolicy(vsls.PolicyTitle.AllowedDomains, [
-      "microsoft.com",
-      "github.com"
-    ]),
-
-    new GenericPolicy(vsls.PolicyTitle.AllowGuestDebugControl, false, true),
-    new GenericPolicy(vsls.PolicyTitle.AllowGuestTaskControl, false, true)
-  ];
+  providePolicies(): vsls.Policy[] {
+    return [
+      new GenericPolicy(vsls.PolicyTitle.AnonymousGuestApproval, "reject"),
+      new GenericPolicy(vsls.PolicyTitle.ConnectionMode, "relay"),
+      new GenericPolicy(vsls.PolicyTitle.AutoShareServers, false),
+      new GenericPolicy(vsls.PolicyTitle.AllowReadWriteTerminals, false),
+      new GenericPolicy(vsls.PolicyTitle.AllowedDomains, [
+        "microsoft.com",
+        "github.com"
+      ]),
+  
+      new GenericPolicy(vsls.PolicyTitle.AllowGuestDebugControl, false, true),
+      new GenericPolicy(vsls.PolicyTitle.AllowGuestTaskControl, false, true)
+    ];
+  }
 }
 
 class GenericPolicy implements vsls.Policy {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ class TestPolicyProvider implements vsls.PolicyProvider {
       "microsoft.com",
       "github.com"
     ]),
-    new GenericPolicy(vsls.PolicyTitle.ReadOnlyTerminal, true)
+    new GenericPolicy(vsls.PolicyTitle.ReadOnlyTerminals, true)
   ];
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,7 @@
 import * as vscode from "vscode";
 import * as vsls from "vsls";
 
-const EXTENSION_NAME = "liveshare";
 export async function activate(context: vscode.ExtensionContext) {
-  // Ensure the neccessary settings are
-  // re-enforced for the end-user.
-  await enforceSettings();
 
   // This extension takes a hard depedency on
   // Live Share, so it will always be available.
@@ -14,59 +10,29 @@ export async function activate(context: vscode.ExtensionContext) {
   // Wait for any guests to attempt to join
   // a collaboration session, in order to
   // determine if they're allowed in or not.
-  api.onDidChangePeers((e) => {
-    e.added.forEach((peer) => {
-      // If the current user doesn't have an e-mail address, then
-      // there's no point in us trying to match it against guests.
-      const selfDomain = api.session.user?.emailAddress?.split("@")[1];
-      if (!selfDomain) {
-        return;
-      }
 
-      // If the incoming user doesn't have an e-mail address,
-      // then immediately remove them, since anonymous/unknown
-      // guests aren't allowed, regardless of the host's settings.
-      const emailDomain = peer.user?.emailAddress?.split("@")[1];
-      if (!emailDomain) {
-        return removeUser(peer.peerNumber);
-      }
-
-      // If the incoming user is from the same domain
-      // as the host, then they're immediately allowed.
-      if (selfDomain.localeCompare(emailDomain) === 0) {
-        return;
-      }
-
-      const allowedDomains: string[] = vscode.workspace
-        .getConfiguration(EXTENSION_NAME)
-        .get("allowedDomains", []);
-
-      // If the incoming user is from a different domain,
-      // which hasn't been whitelisted, then remove them.
-      if (!allowedDomains.includes(emailDomain)) {
-        removeUser(peer.peerNumber);
-      }
-    });
-  });
+  let policyProvider = new TestPolicyProvider();
+  api.registerPolicyProvider("Test Policy Provider", policyProvider);
 }
 
-function removeUser(peerNumber: number) {
-  vscode.commands.executeCommand(`${EXTENSION_NAME}.removeParticipant`, {
-    sessionId: peerNumber,
-  });
+class TestPolicyProvider implements vsls.PolicyProvider {
+
+  policies: vsls.Policy[] = [
+    new GenericPolicy(vsls.SettingKey.AllowGuestDebugControl, false)
+  ];
 }
 
-const SETTINGS = [
-  "allowGuestDebugControl",
-  "allowGuestTaskControl",
-  "autoShareServers"
-];
+class GenericPolicy implements vsls.Policy {
 
-async function enforceSettings() {
-  const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
-  return Promise.all(
-    SETTINGS.map((setting) =>
-      config.update(setting, false, vscode.ConfigurationTarget.Global)
-    )
-  );
+  constructor(settingKey: vsls.SettingKey, value: any, isUserLevel: boolean = true) {
+    this.isUserLevel = isUserLevel;
+    this.value = value;
+    this.settingKey = settingKey;
+  }
+
+  isUserLevel: boolean;
+  
+  value: any;
+  
+  settingKey: vsls.SettingKey;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,13 +14,17 @@ export async function activate(context: vscode.ExtensionContext) {
 class TestPolicyProvider implements vsls.PolicyProvider {
 
   policies: vsls.Policy[] = [
-    new GenericPolicy(vsls.PolicyTitle.AnonymousGuestApproval, "accept"),
-    new GenericPolicy(vsls.PolicyTitle.AllowGuestDebugControl, false),
+    new GenericPolicy(vsls.PolicyTitle.AnonymousGuestApproval, "reject"),
+    new GenericPolicy(vsls.PolicyTitle.ConnectionMode, "direct"),
+    new GenericPolicy(vsls.PolicyTitle.AutoShareServers, false),
+    new GenericPolicy(vsls.PolicyTitle.ReadOnlyTerminals, true),
     new GenericPolicy(vsls.PolicyTitle.AllowedDomains, [
       "microsoft.com",
       "github.com"
     ]),
-    new GenericPolicy(vsls.PolicyTitle.ReadOnlyTerminals, true)
+
+    new GenericPolicy(vsls.PolicyTitle.AllowGuestDebugControl, false, true),
+    new GenericPolicy(vsls.PolicyTitle.AllowGuestTaskControl, false, true)
   ];
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,9 @@ export async function activate(context: vscode.ExtensionContext) {
 class TestPolicyProvider implements vsls.PolicyProvider {
 
   policies: vsls.Policy[] = [
-    new GenericPolicy(vsls.SettingKey.AllowGuestDebugControl, false)
+    new GenericPolicy(vsls.SettingKey.AllowGuestDebugControl, false),
+    new GenericPolicy(vsls.SettingKey.AllowGuestTaskControl, false),
+    new GenericPolicy(vsls.SettingKey.AutoShareServers, false)
   ];
 }
 


### PR DESCRIPTION
Please do not merge this PR until we have the new policy API released in VSLS.

The original version of `gatekeeper` is primarily based on configuration flags. The version in this PR is modified to work with VSLS policy API, that is a re-fined version of config flags that supports a couple of extra features:

* Config merge (for situations where we might have multiple extensions competing for the same setting)
* Enforcement of domain restrictions and terminal read/write permissions